### PR TITLE
Fix responsivity for mobile

### DIFF
--- a/index-automated.html
+++ b/index-automated.html
@@ -64,12 +64,11 @@
         }
 
         .content {
-          display: grid;
           margin-bottom: 40px;
         }
 
         .container {
-          display: grid;
+          
         }
 
         .maxWidth {

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
           Santa Clara, CA 95051</p>
         <p>Please mail to: 2250 Latham St, Apt 27, Mountain View, CA 94040</p>
         <p>N95s unopened, N95s in open box or bag, Surgical masks unopened, Surgical masks opened, Face shields</p>
-      
+
       <h3>Santa Cruz</h3>
       <h4 class="marginBottomZero">Dominican Hospital</h4>
       <p class="marginTopZero med Emph">1555 Soquel Dr<br>
@@ -128,14 +128,14 @@
         San Jose, CA 95128</p>
         <p>They have parking right outside (don't be discouraged by the construction) and would be very happy to receive your donations of face shields and N-95s (including open packages). They are open from 8 am to 5 pm. Monday through Friday.</p>
 
-      
+
       <h2>Maine</h2>
       <h3>Bangor</h3>
       <h4 class="marginBottomZero">Northern Light Health</h4>
-      <p class="marginTopZero medEmph">70 Bennett Street, Bangor<br> 
+      <p class="marginTopZero medEmph">70 Bennett Street, Bangor<br>
          Bangor, ME 04401
       </p>
-      <p>Deliver to Warehouse Front office</p> 
+      <p>Deliver to Warehouse Front office</p>
       <p>Open boxes okay, must be clean/undamaged. N95s, Surgical masks, Face shields, Safety goggles, Gloves, hand sanitizer and sanitizing wipes</p>
 
         <h2 class="addMoreTopMargin">Massachusetts</h2>
@@ -143,7 +143,7 @@
       <h3>Boston</h3>
       <h4  class="marginBottomZero">Beth Israel Deaconess Medical Center</h4>
       <p class="marginTopZero medEmph">330 Brookline Ave<br>
-        
+
       <h4 class="marginBottomZero">Boston Medical Center</h4>
       <p class="marginTopZero medEmph">750 Albany Street<br>
         Boston, MA 02119</p>
@@ -180,14 +180,14 @@
         <p>Mail N95s and surgical masks (opened ok), gloves, goggles, booties to: Alexa Parker, Emergency Dept.- NNMC, 2375 E Prater Way, Sparks, NV, 89431</p>
 
         <h2>New York</h2>
-      
+
       <h3>The Bronx</h3>
         <h4 class="marginBottomZero">Lincoln Medical Center</h4>
         <p class="marginTopZero medEmph">234 E 149th St<br>
           The Bronx, NY 10451</p>
         <p>Drop-off in Main Lobby, Contact Mrs. Gretta Bane, ADN (646)271-5119</p>
         <p>N95s unopened, N95s in open box or bag, Surgical masks unopened, Surgical masks opened, Disposable booties, Safety goggles, Gloves, Face shields, Hand sanitizer</p>
-      
+
       <h3>Brooklyn</h3>
       <h4 class="marginBottomZero">Woodhull Hospital</h4>
 	    <p class="marginTopZero medEmph">760 Broadway<br>
@@ -195,7 +195,7 @@
 
       <p>Drop off at front desk and tell them the donations are for the ED (emergency department)</p>
       <p>N95s, Surgical masks, Gloves. Not sure if open-box is ok.</p>
-      
+
         <h3>Buffalo</h3>
         <h4 class="marginBottomZero">University Orthopaedics</h4>
         <p class="marginTopZero medEmph">Erie County Medical Center<br>
@@ -204,7 +204,7 @@
           Attn: karen Taylor PA-C, UBortho #2"
         </p>
         <p>N95s unopened, N95s in open box or bag, Surgical masks unopened, Surgical masks opened, Gloves, Face shields</p>
-      
+
         <h3>Canandaigua</h3>
         <h4 class="marginBottomZero">Thompson Hospital</h4>
         <p class="marginTopZero medEmph">350 Parrish Street<br>
@@ -221,7 +221,7 @@
         <p>N95s, surgical masks, face shields unopened. Call 580-379-5000 and ask for Mary Jencks.</p>
 
         <h2 class="addMoreTopMargin">Oregon</h2>
-    
+
         <h3>Clackamas</h3>
          <h4 class="marginBottomZero">Providence Sunnyside Clinic<br>
            9290 SE Sunnybrook Blvd Suite 120<br>
@@ -229,7 +229,7 @@
         </p>
         <p>Leave at front desk</p>
         <p>Open box/bag ok. N95s, Surgical masks, Face shields, Disposable booties, Safety goggles, Gloves</p>
-       
+
         <h3>Newport</h3>
         <p>930 SW Abbey St<br>
           Newport, OR 97365</p>
@@ -272,7 +272,7 @@
         <h4 class="marginBottomZero">Franciscan Women's Health Associates - Burien</h4>
         <p class="marginTopZero medEmph">16045 1st Ave S<br>
         Burien, WA 98148</p>
-      
+
       <h3>Issaquah</h3>
       <h4 class="marginBottomZero">Swedish Issaquah</h4>
       <p class="marginTopZero medEmph">751 NE Blakely Dr<br>
@@ -280,7 +280,7 @@
       <p>Option 1: Drop the supplies outside of the ER entrance in a plastic bag with some sort of label or signage that they’re donated supplies.<br>
         Option 2: Stay in your car and call (425)394-0610 and someone will come out to retrieve them."</p>
       <p>N95s unopened, N95s in open box or bag, Surgical masks unopened, Surgical masks opened, Face shields. Feel free to leave a note of encouragement.  </p>
-      
+
       <h3>Lakewood</h3>
       <h4 class="marginBottomZero">St. Clare Hospital</h4>
       <p class="marginTopZero medEmph">11315 Bridgeport Way SW<br>
@@ -296,7 +296,7 @@
       <p>No open boxes/bags. Surgical masks, Gloves, Vinyl or nitrile gloves, liquid hand sanitizer</p>
 
 
-  
+
         h3>Edmonds</h3>
         <h4 class="marginBottomZero">Swedish Edmonds</h4>
         <p class="marginTopZero medEmph">21601 76th Ave West<br>
@@ -349,8 +349,8 @@
         Seattle, WA 98107</p>
 
         <p>Accepting open or unopened boxes and bags of N95s and surgical masks. Put in donations bin at registration desk or at medical treatment center.</p>
-     
-        <h4 class="marginBottomZero">Seattle Cancer Care Alliance</h4> 
+
+        <h4 class="marginBottomZero">Seattle Cancer Care Alliance</h4>
 	      <p class="marginTopZero medEmph">1354 Aloha St <br>
 	       Seattle, WA 98109</p>
       <p>PPE can be dropped off at the front desk attn: Kim Koegel, or a nurse can come pick it up directly from your car in the front drive. Call (206) 606-1329 for direct nurse pickup from your car.</p>
@@ -363,8 +363,8 @@
 
       <p>Got a comment or suggestion? Want to help? contact@findthemasks.com or add directly on <a href="https://github.com/r-pop/findthemasks">our Github</a>.</p>
 
-      <p class="centerText end">made with <3 in Seattle</p>
-      <a href="whoweare.html">who we are</a></p>
+      <p class="centerText">made with <3 in Seattle</p>
+      <p class="centerText"><a href="whoweare.html" class="end">who we are</a></p>
 
     </article>
   </main>

--- a/style.css
+++ b/style.css
@@ -45,11 +45,11 @@ body {
 }
 
 .content {
-  display: grid;
+
 }
 
 .container {
-  display: grid;
+
 }
 
 .maxWidth {
@@ -161,4 +161,3 @@ body {
   font-weight: 600;
   text-transform: uppercase;
 }
-


### PR DESCRIPTION
Removed `display: grid` from css classes. This should fix responsivity across browsers and screen widths.

–unsure *why* this was broken, but that's ok for now–