### PR TITLE
Fix for #140: Redirect users away from 'www' prefix (hostname agnostic), carry over request URI.

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,5 +1,13 @@
+RewriteEngine On
+
+# First: Always ensure we're going over HTTPS.
 RewriteCond %{HTTPS} !=on
 RewriteRule ^(.*) https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+# Redirect to the WWW domain after already on HTTPS.
+RewriteCond %{HTTPS} on
+RewriteCond %{HTTP_HOST} ^www\.(.*)$
+RewriteRule .* https://%1%{REQUEST_URI} [L,R=301]
 
 <IfModule mod_headers.c>
   <Files "data.json">
@@ -7,7 +15,7 @@ RewriteRule ^(.*) https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
   </Files>
 </IfModule>
 
-<IfModule mod_expires.c>  
+<IfModule mod_expires.c>
   # Turn on the module.
   ExpiresActive on
   # Set the default expiry times.
@@ -24,4 +32,4 @@ RewriteRule ^(.*) https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
   ExpiresByType image/ico "access plus 300 seconds"
   ExpiresByType image/x-icon "access plus 300 seconds"
   ExpiresByType text/html "access plus 300 seconds"
-</IfModule>  
+</IfModule>


### PR DESCRIPTION
Fix for #140: Redirect users away from 'www' prefix (hostname agnostic), carry over request URI.

You can test this with `curl -v -H 'Host: www.findthemasks.com' http://127.0.0.1/` as well if you spoof the domain in the host header (e.g. see `-H` param). But you can also test locally after commenting out the HTTPS redirect and manually tweaking the redirect line and then using your hosts file to map both domains to your localhost machine (or whatever machine you're doing dev on, I used `dev.findthemasks.com` as my local dev domain). See below where I demonstrate this.

Also note: This also **fixes** a bug in the `.htaccess` file, since the first `https://` rewrite rule wasn't even working at all since `RewriteEngine On` must be called first. 

**⚠️Caution:⚠️** I'm not sure how those first two lines will work, it depends on the underlying architecture and if Apache is really convinced that `HTTPS` is `on`. Usually upstream servers (like yours) will be over plain text HTTP and therefore `HTTPS` will not actually be `on`, however CDN services like CloudFlare and Akamai will typically incorporate the `X-Forwarded-Proto: https` header, which you could check instead. So be sure to test this with the ability to revert quickly, or test on another domain.

![2020-03-23_01-48-19](https://user-images.githubusercontent.com/4269377/77298943-ef1a3880-6ca8-11ea-8d26-eae5662d74e7.gif)
