### PR TITLE
Load the google maps script with 'defer' only, not 'async'.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     </script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <!-- API Key below is only enabled for *.findthemasks.com/* Message @susanashlock for more info. -->
-    <script async defer
+    <script defer
             src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDSz0lnzPJIFeWM7SpSARHmV-snwrAXd2s&libraries=geometry">
     </script>
     <script src="locations-list-map.js"></script>


### PR DESCRIPTION
This should prevent a race condition where initMap (via
DOMContentLoaded) can sometimes be called before the map script has been
downloaded.