### PR TITLE
Fix bug when filtering by state in Edge.

### DIFF
--- a/public/locations-list-map.js
+++ b/public/locations-list-map.js
@@ -289,6 +289,13 @@ window.onFilterChange = function (elem, scrollNeeded) {
   }
 };
 
+
+// Polyfill required for Edge for the .forEach methods above, since this method doesn't exist in that browser.
+if (window.HTMLCollection && !HTMLCollection.prototype.forEach) {
+  HTMLCollection.prototype.forEach = Array.prototype.forEach;
+}
+
+
 const stateLocationMappings = {
   "AK": { "lat": 63.588753, "lng": -154.493062, zoom: 3.5 },
   "AL": { "lat": 32.318231, "lng": -86.902298, zoom: 6 },


### PR DESCRIPTION
This adds a polyfill for Edge to fix bug when filtering by state; due to lack of support for HTMLCollection.prototype.forEach. See below.

![2020-03-25_17-36-33](https://user-images.githubusercontent.com/4269377/77598583-73460900-6ebf-11ea-9c1f-445ae796a1c3.png)
